### PR TITLE
fix weekly digest generation day

### DIFF
--- a/src/app/[userID]/_parts/CreatePeriodDigestPlugin.tsx
+++ b/src/app/[userID]/_parts/CreatePeriodDigestPlugin.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 
 import dayjs from "dayjs";
+import isoWeek from "dayjs/plugin/isoWeek";
+dayjs.extend(isoWeek);
 
 import { useCreateDigest, useGetLatestDigestDate } from "@/services/digests";
 
@@ -15,7 +17,7 @@ const CreatePeriodDigestPlugin = (): null => {
   useEffect(() => {
     if (isLoading) return;
 
-    const shouldCreateDigest = date ? dayjs(date).isBefore(dayjs().startOf("week")) : true;
+    const shouldCreateDigest = date ? dayjs(date).isBefore(dayjs().startOf("isoWeek")) : true;
 
     const formattedDate = dayjs().format("YYYY-MM-DD");
 


### PR DESCRIPTION
Making the change to isoWeek so that weekly digest is always generated as from Monday

- startOf('isoWeek') will always return Monday
- it follows the ISO 8601 standard, which defines Monday as the first day of the week — regardless of locale.